### PR TITLE
minor unmarshalling error

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -200,7 +200,13 @@ public struct Mapper {
     public func from<T: Mappable>(field: String) throws -> [T] {
         let value = try self.JSONFrom(field: field)
         if let JSON = value as? [[AnyHashable: Any]] {
-            return try JSON.map { try T(map: Mapper(JSON: $0)) }
+            return JSON.compactMap {
+                do {
+                    return try T(map: Mapper(JSON: $0))
+                } catch {
+                    return nil
+                }
+            }
         }
 
         throw MapperError.typeMismatchError(field: field, value: value, type: [[AnyHashable: Any]].self)


### PR DESCRIPTION
fix arrays in objects not being compact mapped.  

tested this locally with Anna's repro-case (unsupported types of spotify and instagram in the json).  Worked like a charm!

note: Feed works correctly because the total response is an array.  For some reason if the response is an array the mapper library works correctly.  But if an object, and the object has an array, this function was being called instead of whatever was being called in the other case.  

This function wasn't doing a compact map case, now it is